### PR TITLE
Fix: Open generics inheritance ignored based on registration order (AutoMapper #4567 backport)

### DIFF
--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -168,7 +168,7 @@ public sealed class ProfileMap
     }
     private void Configure(TypeMapConfiguration typeMapConfiguration, IGlobalConfiguration configuration)
     {
-        var typeMap = typeMapConfiguration.TypeMap;
+        var typeMap = configuration.FindTypeMapFor(typeMapConfiguration.Types) ?? typeMapConfiguration.TypeMap;
         if (typeMap.IncludeAllDerivedTypes)
         {
             IncludeAllDerived(configuration, typeMap);

--- a/src/UnitTests/Bug/OpenGenericInheritanceOrder.cs
+++ b/src/UnitTests/Bug/OpenGenericInheritanceOrder.cs
@@ -1,0 +1,38 @@
+namespace AutoMapper.UnitTests.Bug;
+
+public class OpenGenericInheritanceOrder
+{
+    class FooBar { }
+    class SourceBase<T> { public string Name { get; set; } }
+    class DestinationBase { public string Name { get; set; } }
+    class SourceDerived : SourceBase<FooBar> { }
+    class DestinationDerived : DestinationBase { }
+
+    [Fact]
+    public void Should_work_when_derived_map_declared_before_open_generic_base_map()
+    {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<SourceDerived, DestinationDerived>()
+                .IncludeBase<SourceBase<FooBar>, DestinationBase>();
+            cfg.CreateMap(typeof(SourceBase<>), typeof(DestinationBase));
+        });
+
+        var result = config.CreateMapper().Map<DestinationDerived>(new SourceDerived { Name = "test" });
+        result.Name.ShouldBe("test");
+    }
+
+    [Fact]
+    public void Should_work_when_open_generic_base_map_declared_first()
+    {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap(typeof(SourceBase<>), typeof(DestinationBase));
+            cfg.CreateMap<SourceDerived, DestinationDerived>()
+                .IncludeBase<SourceBase<FooBar>, DestinationBase>();
+        });
+
+        var result = config.CreateMapper().Map<DestinationDerived>(new SourceDerived { Name = "test" });
+        result.Name.ShouldBe("test");
+    }
+}


### PR DESCRIPTION
### Description
This PR backports a fix from AutoMapper (#4567) to ensure open generic inheritance works consistently, regardless of the order in which the maps are registered.

**The Issue:**
When a derived concrete map (e.g., `CreateMap<SourceDerived, DestinationDerived>()`) is declared *before* its open generic base map, the inheritance configuration is ignored. It only works if declared in the reverse order. This happens because the configuration captures the initial instance of the `TypeMap` before the open generics are fully resolved.

**The Fix:**
Updated `ProfileMap.cs` to resolve the inherited `TypeMap` directly from the `GlobalConfiguration` rather than using the currently instanced `TypeMapConfiguration`. This guarantees that the fully materialized type map is used, making the registration order irrelevant.

**References:**
- Original AutoMapper Fix: AutoMapper/AutoMapper#4567