### PR TITLE
Fix: PascalCaseNamingConvention splits consecutive uppercase acronyms (AutoMapper #4593 backport)

### DIFF
--- a/src/AutoMapper/Configuration/INamingConvention.cs
+++ b/src/AutoMapper/Configuration/INamingConvention.cs
@@ -24,7 +24,8 @@ public sealed class PascalCaseNamingConvention : INamingConvention
         int lower = 0;
         for(int index = 1; index < input.Length; index++)
         {
-            if (char.IsUpper(input[index]))
+            if (char.IsUpper(input[index]) &&
+                (!char.IsUpper(input[index - 1]) || (index + 1 < input.Length && !char.IsUpper(input[index + 1]))))
             {
                 result ??= [];
                 result.Add(input[lower..index]);

--- a/src/UnitTests/Bug/NamingConventions.cs
+++ b/src/UnitTests/Bug/NamingConventions.cs
@@ -105,6 +105,24 @@ public class When_mapping_with_lowercase_naming_conventions_two_ways_in_profiles
     }
 }
 
+
+public class PascalCaseAcronymInPropertyName : AutoMapperSpecBase
+{
+    class Source { public Inner Form { get; set; } }
+    class Inner { public int XML { get; set; } }
+    class Dest { public int FormXML { get; set; } }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+        cfg.CreateMap<Source, Dest>());
+
+    [Fact]
+    public void Should_flatten_acronym_property()
+    {
+        var result = Mapper.Map<Dest>(new Source { Form = new Inner { XML = 42 } });
+        result.FormXML.ShouldBe(42);
+    }
+}
+
 public class When_mapping_with_lowercase_naming_conventions_two_ways : AutoMapperSpecBase
 {
     private Dario _dario;


### PR DESCRIPTION
### Description
This PR backports a fix from AutoMapper (#4593) to address an issue where `PascalCaseNamingConvention` incorrectly splits consecutive uppercase letters (acronyms).

**The Issue:**
When mapping properties containing acronyms like `FormXML`, the `Split` method previously separated every single uppercase letter (`Form`, `X`, `M`, `L`), causing the mapping convention to fail to match the properties.

**The Fix:**
Updated the splitting condition to verify if the current uppercase letter is surrounded by other uppercase letters. It now correctly identifies acronyms and keeps them intact (e.g., `FormXML` correctly splits into `Form` and `XML`).

**References:**
- Original AutoMapper Fix: AutoMapper/AutoMapper#4593