### PR TITLE
Fix: MapAtRuntime exception with nullable target types and extension methods (AutoMapper #4597 backport)

### DIFF
--- a/src/AutoMapper/Execution/ExpressionBuilder.cs
+++ b/src/AutoMapper/Execution/ExpressionBuilder.cs
@@ -168,7 +168,8 @@ public static class ExpressionBuilder
     public static Expression ContextMap(TypePair typePair, Expression sourceParameter, Expression destinationParameter, MemberMap memberMap)
     {
         var mapMethod = ContextMapMethod.MakeGenericMethod(typePair.SourceType, typePair.DestinationType);
-        return Expression.Call(ContextParameter, mapMethod, sourceParameter, destinationParameter, Constant(memberMap, typeof(MemberMap)));
+        var source = ToType(sourceParameter, typePair.SourceType);
+        return Expression.Call(ContextParameter, mapMethod, source, destinationParameter, Constant(memberMap, typeof(MemberMap)));
     }
     public static Expression CheckContext(TypeMap typeMap) => typeMap.PreserveReferences || typeMap.MaxDepth > 0 ? CheckContextCall : null;
     public static Expression OverMaxDepth(TypeMap typeMap) => typeMap?.MaxDepth > 0 ? 

--- a/src/UnitTests/Bug/MapAtRuntime/MapAtRuntimeWithExtensionMethodAndNullable.cs
+++ b/src/UnitTests/Bug/MapAtRuntime/MapAtRuntimeWithExtensionMethodAndNullable.cs
@@ -1,0 +1,48 @@
+namespace AutoMapper.UnitTests.Bug;
+
+public class MapAtRuntimeWithExtensionMethodAndNullable
+{
+    class SourceObject { public string MyValue { get; set; } }
+    class DestObject { public int? MyValue { get; set; } }
+
+    [Fact]
+    public void Should_handle_extension_method_with_nullable_destination()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<SourceObject, DestObject>()
+                .ForMember(dest => dest.MyValue, opt =>
+                {
+                    opt.MapFrom(src => src.MyValue.ExtractInt());
+                    opt.MapAtRuntime();
+                });
+        }).CreateMapper();
+
+        var result = mapper.Map<DestObject>(new SourceObject { MyValue = "1" });
+
+        result.MyValue.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Should_handle_null_source_member_with_extension_method_and_nullable_destination()
+    {
+        var mapper = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<SourceObject, DestObject>()
+                .ForMember(dest => dest.MyValue, opt =>
+                {
+                    opt.MapFrom(src => src.MyValue.ExtractInt());
+                    opt.MapAtRuntime();
+                });
+        }).CreateMapper();
+
+        var result = mapper.Map<DestObject>(new SourceObject { MyValue = null });
+
+        result.MyValue.ShouldBeNull();
+    }
+}
+
+static class NullableExtensionMethodHelpers
+{
+    public static int? ExtractInt(this string str) => str == null ? null : int.Parse(str);
+}


### PR DESCRIPTION
### Description
This PR backports a fix from AutoMapper (#4597) to resolve a runtime exception when combining `.MapAtRuntime()` with extension methods targeting a nullable type.

**The Issue:**
When using `.MapAtRuntime()` alongside `.MapFrom(src => src.Value.ExtensionMethod())` where the destination type is nullable (e.g., `int?`), the mapping throws a runtime exception. The expression builder passes the source parameter directly without explicitly converting it to the expected type of the generic expression.

**The Fix:**
Added an explicit `ToType()` (or `Expression.Convert`) cast to the source parameter inside `ContextMap` before passing it to the `Expression.Call`. This ensures type safety and prevents the runtime crash.

**References:**
- Original AutoMapper Fix: AutoMapper/AutoMapper#4597